### PR TITLE
Removed unneeded new line at end of sass-lint.yml file.

### DIFF
--- a/sass-lint.yml
+++ b/sass-lint.yml
@@ -47,4 +47,3 @@ rules:
         - 'alphabetical'
       ignore-custom-properties: true
   pseudo-element: false
-


### PR DESCRIPTION
There are two new lines at the end of this file. This can cause an error in Travis CI builds when the theme is run through Drupal coding standard checks. Removing one of the lines fixes the error.