### PR TITLE
Fix eslint issues that appear when using with Drupal 8.6.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "parser": "babel-eslint"
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -100,7 +100,7 @@ gulp.task('iconfont', () => {
 });
 
 gulp.task('eslint', () => {
-  gulp.src(paths.scripts)
+  return gulp.src(paths.scripts)
     .pipe(eslint({
       parser: 'babel-eslint',
       rules: {


### PR DESCRIPTION
The .eslintrc.json file will prevent `gulp eslint` commands from using Drupal's eslint configuration.