### PR TITLE
Replace unsupported browsers option with browserslist key in package.json

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,11 +67,7 @@ gulp.task('scss', () => {
     .pipe(sassGlob())
     .pipe(sass({outputStyle: 'compressed'}))
     .pipe(cssnano({zindex: false}))
-    .pipe(postcss([
-      prefix({
-        browsers: ['last 3 versions'],
-        cascade: false })
-      ]))
+    .pipe(postcss([prefix({cascade: false})]))
     .pipe(sourcemaps.write('maps'))
     .pipe(gulp.dest(paths.styles.dist))
     .pipe(reload({stream:true}));

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "gulp-sourcemaps": "^2.6.4",
     "gulp-terser": "^1.1.7",
     "kss": "^3.0.0-beta.25"
-  }
+  },
+  "browserslist": [
+    "last 3 versions"
+  ]
 }


### PR DESCRIPTION
```  Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.

  Using browsers option cause some error. Browserslist config
  can be used for Babel, Autoprefixer, postcss-normalize and other tools. 

  Learn more at:  https://github.com/browserslist/browserslist#readme```